### PR TITLE
Update GitHub workflows and suppress unused parameter warnings

### DIFF
--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -3,8 +3,13 @@ name: PHPMD
 
 on:
   push:
-    branches:
-      - 'Feature/*'
+    branches-ignore:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches-ignore:
+      - 'main'
+      - 'develop'
 
 jobs:
   phpstan:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -6,8 +6,13 @@ name: PHPStan
 
 on:
   push:
-    branches:
-      - 'Feature/*'
+    branches-ignore:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches-ignore:
+      - 'main'
+      - 'develop'
 
 jobs:
   phpstan:
@@ -15,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: composer-${{ hashFiles('**/composer.lock') }}
@@ -28,7 +33,7 @@ jobs:
             composer-
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -3,8 +3,13 @@ name: Pint
 
 on:
   push:
-    branches:
-      - 'Feature/*'
+    branches-ignore:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches-ignore:
+      - 'main'
+      - 'develop'
 
 jobs:
   phpstan:
@@ -12,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: composer-${{ hashFiles('**/composer.lock') }}
@@ -25,7 +30,7 @@ jobs:
             composer-
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/ci-scripts/PhpMD/PhpMDAnalyzer.php
+++ b/ci-scripts/PhpMD/PhpMDAnalyzer.php
@@ -18,7 +18,7 @@ class PhpMDAnalyzer extends Analyzer
         parent::__construct(
             'PHP Mess Detector',
             <<<CMD
-            ./vendor/bin/phpmd %FILES% ansi cleancode,codesize,controversial,design,unusedcode --exclude *vendors
+            ./vendor/bin/phpmd %FILES% ansi cleancode,codesize,controversial,design,unusedcode --exclude *vendor/
             CMD,
             $args,
         );

--- a/ci-scripts/Pint/pint.json
+++ b/ci-scripts/Pint/pint.json
@@ -1,3 +1,6 @@
 {
-    "preset": "per"
+    "preset": "per",
+    "exclude": [
+        "vendor/"
+    ]
 }

--- a/src/JsonApiFormatPaginateServiceProvider.php
+++ b/src/JsonApiFormatPaginateServiceProvider.php
@@ -41,6 +41,9 @@ class JsonApiFormatPaginateServiceProvider extends ServiceProvider
      *
      * This method registers a macro for querying models, allowing to retrieve all the
      * fields (fillable and hidden) of the model.
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     *  Suppress StaticAccess, because we are using EloquentBuilder
      */
     protected function registerMacro(): void
     {

--- a/src/Transformers/EntityResourceTransformer.php
+++ b/src/Transformers/EntityResourceTransformer.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Str;
 use ReflectionClass;
-use ReflectionException;
 
 /**
  * Class JsonApiPaginationTransformer
@@ -37,7 +36,8 @@ class EntityResourceTransformer extends JsonResource
      *
      * @return array<int|string, mixed>
      *
-     * @throws ReflectionException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *  Suppress UnusedFormalParameter, because we are using JsonResource
      */
     public function toArray(Request $request): array
     {

--- a/src/Transformers/JsonApiResourceTransformer.php
+++ b/src/Transformers/JsonApiResourceTransformer.php
@@ -20,6 +20,9 @@ class JsonApiResourceTransformer extends JsonResource
      * Transform the resource collection into an array.
      *
      * @return array<int|string, mixed>|Arrayable|JsonSerializable
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *  Suppress UnusedFormalParameter, because we are using JsonResource
      */
     public function toArray(Request $request): array|Arrayable|JsonSerializable
     {


### PR DESCRIPTION
⚙️ config(ci): ignore 'main' and 'develop' branches for push and PR events
🔧 chore(ci): update GitHub actions to latest versions (checkout@v4, cache@v4)
🐛 fix(ci): correct `phpmd` exclude path to `*vendor/`
✨ feat(pint): add vendor exclusion in pint configuration
🛠️ refactor(phpmd): suppress StaticAccess and UnusedFormalParameter warnings in transformers